### PR TITLE
Do deep copy of MessagePlaintext in resend.go.

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -44,8 +44,11 @@ func (r *resendContext) later(msg MessagePlaintext, opaque ...interface{}) {
 	if r.messages.m == nil {
 		r.messages.m = make([]messageToResend, 0, 5)
 	}
-
-	r.messages.m = append(r.messages.m, messageToResend{msg, opaque})
+	mtr := messageToResend{
+		m:      append(MessagePlaintext(nil), msg...),
+		opaque: opaque,
+	}
+	r.messages.m = append(r.messages.m, mtr)
 }
 
 func (r *resendContext) pending() []messageToResend {


### PR DESCRIPTION
Not doing so led to sending of zero-filled messages.
This bug was introduced in 0f024454fd8a29bb7b59ca00515b67f8328a6151.

btw, what's the reason for `MessagePlaintext` being `[]byte` and not `string`?